### PR TITLE
Sort dates to group opened/closed

### DIFF
--- a/_includes/dates.html
+++ b/_includes/dates.html
@@ -7,6 +7,12 @@
           <tr><td><a href="{{ site.baseurl }}/registration/">Registration</a></td><td>Publication Fee</td><td>17 August 2020</td></tr>
           <tr><td></td><td>Early Bird Registration</td><td>31 August 2020</td></tr>
           <tr><td></td><td></td></tr>
+          <tr><td><a href="{{ site.baseurl }}/call_for_lbd/">Call for LBDs</a></td><td><b>Open</b></td></tr>
+          <tr><td>Initial Submission</td><td>22 September 2020</td><td></td></tr>
+          <tr><td>Revisions (if necessary)</td><td>23-25 September 2020</td><td></td></tr>
+          <tr><td>LBDs Notification</td><td>28 September 2020</td><td></td></tr>
+          <tr><td>Poster/Video Submission</td><td>5 October 2020</td><td></td></tr>
+          <tr><td></td><td></td></tr>
           <tr><td><a href="{{ site.baseurl }}/cfp/">Call for Papers</a></td><td><b>Closed</b></td></tr>
           <tr><td>Abstract Submission</td><td style="text-decoration: line-through;">10 April 2020</td><td>8 May 2020</td></tr>
           <tr><td>Final Submission</td><td style="text-decoration: line-through;">17 April 2020</td><td>15 May 2020</td></tr>
@@ -21,12 +27,6 @@
           <tr><td>Initial Submission</td><td style="text-decoration: line-through;">30 April 2020</td><td>22 May 2020</td></tr>
           <tr><td>Final Submission</td><td style="text-decoration: line-through;">22 May 2020</td><td>29 May 2020</td></tr>
           <tr><td>Tutorials Notification</td><td style="text-decoration: line-through;">15 June 2020</td><td>22 June 2020</td></tr>
-          <tr><td></td><td></td></tr>
-          <tr><td><a href="{{ site.baseurl }}/call_for_lbd/">Call for LBDs</a></td><td><b>Open</b></td></tr>
-          <tr><td>Initial Submission</td><td>22 September 2020</td><td></td></tr>
-          <tr><td>Revisions (if necessary)</td><td>23-25 September 2020</td><td></td></tr>
-          <tr><td>LBDs Notification</td><td>28 September 2020</td><td></td></tr>
-          <tr><td>Poster/Video Submission</td><td>5 October 2020</td><td></td></tr>
         </tbody>
       </table>
     </div>

--- a/dates.md
+++ b/dates.md
@@ -12,6 +12,14 @@ permalink: /dates/
 
 <br>
 
+| [Call for Late-Breaking/Demo]({{ site.baseurl }}/call_for_lbd/)           | **Open** |
+| Initial submission           | 22 September 2020       | |
+| Request for revision, if necessary             |  23-25 September 2020       | |
+| LBD notification       | 28 September 2020      | |
+| Poster/Video submission      | 5 October 2020      | |
+
+<br>
+
 | [Call for Papers]({{ site.baseurl }}/cfp/)             | **Closed**                |                    |
 | Abstract submission         | ~~10 April 2020~~     | 8 May 2020         |
 | Final submission            | ~~17 April 2020~~     | 15 May 2020        |
@@ -30,14 +38,6 @@ permalink: /dates/
 | Initial submission           | ~~30 April 2020~~     | 22 May 2020       |
 | Final submission             | ~~22 May 2020~~       | 29 May 2020       |
 | Tutorials notification       | ~~15 June 2020~~      | 22 June 2020      |
-
-<br>
-
-| [Call for Late-Breaking/Demo]({{ site.baseurl }}/call_for_lbd/)           | **Open** |
-| Initial submission           | 22 September 2020       | |
-| Request for revision, if necessary             |  23-25 September 2020       | |
-| LBD notification       | 28 September 2020      | |
-| Poster/Video submission      | 5 October 2020      | |
 
 <br>
 


### PR DESCRIPTION
Hi @napulen,

This was suggested during this week's org meeting. I have moved LBD dates closer to registration dates, as both are still opened, to improve visibility.

Kind regards,
Christian